### PR TITLE
feat: added new CSS variables (to style of unselected area)

### DIFF
--- a/docs/pages/5.CSS/3.overlay.md
+++ b/docs/pages/5.CSS/3.overlay.md
@@ -1,0 +1,24 @@
++---
+title: overlay
+---
+Unselected areas are covered by default with a semi-transparent black `overlay` element. **You have the option to change the `fill` color and the `opacity` ratio of the `overlay` element .**
+
+### `fill`
+- Default: `black`
+- CSS variable name: `--v-onboarding-overlay-fill`
+How to update
+```css
+:root {
+  --v-onboarding-overlay-fill: lightseagreen;
+}
+```
+
+### `opacity`
+- Default: `0.5`
+- CSS variable name: `--v-onboarding-overlay-opacity`
+How to update
+```css
+:root {
+  --v-onboarding-overlay-opacity: 0.9;
+}
+```

--- a/docs/pages/5.CSS/3.overlay.md
+++ b/docs/pages/5.CSS/3.overlay.md
@@ -1,4 +1,4 @@
-+---
+---
 title: overlay
 ---
 Unselected areas are covered by default with a semi-transparent black `overlay` element. **You have the option to change the `fill` color and the `opacity` ratio of the `overlay` element .**

--- a/src/components/VOnboardingStep.vue
+++ b/src/components/VOnboardingStep.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-show="show">
-    <svg style="width: 100%; height: 100%; position: fixed; top: 0; left: 0; opacity: 0.5; z-index: var(--v-onboarding-overlay-z, 10); pointer-events: none;">
+    <svg style="width: 100%; height: 100%; position: fixed; top: 0; left: 0; fill: var(--v-onboarding-overlay-fill, black); opacity: var(--v-onboarding-overlay-opacity, 0.5); z-index: var(--v-onboarding-overlay-z, 10); pointer-events: none;">
       <path :d="path" />
     </svg>
     <div ref="stepElement" style="position: relative; z-index: var(--v-onboarding-step-z, 20);">


### PR DESCRIPTION
### New variables

Color and transparency of covering an unselected area.

1. `--v-onboarding-overlay-fill` default: black
2. `--v-onboarding-overlay-opacity` default: 0.5

### Example with default (current) values

![image](https://github.com/fatihsolhan/v-onboarding/assets/67325669/d4ce7ea1-69a8-4bc7-9891-939261e02af5)

### Example with custom values

```css
:root {
  --v-onboarding-overlay-fill: lightseagreen;
  --v-onboarding-overlay-opacity: 0.9;
}
```

![image](https://github.com/fatihsolhan/v-onboarding/assets/67325669/f12f5fca-2b55-41ee-9f1e-b27b4f6d07d4)
