### PR TITLE
feat: finish by exit and show/hide exit button

### DIFF
--- a/docs/pages/3.props/2.options.md
+++ b/docs/pages/3.props/2.options.md
@@ -29,9 +29,11 @@ You can override `VOnboardingWrapper`'s options by passing options to `VOnboardi
       inline: 'center'
     }
   },
+  autoFinishByExit: true,
   hideButtons: {
     previous: false,
-    next: false
+    next: false,
+    exit: false
   },
   labels: {
     previousButton: 'Previous',
@@ -51,9 +53,11 @@ You can override `VOnboardingWrapper`'s options by passing options to `VOnboardi
 | `scrollToStep` | | |
 | `scrollToStep.enabled` | `Boolean` | `true` |
 | `scrollToStep.options` | [Scroll Into View Options](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) | `{ behavior: 'smooth', block: 'center', inline: 'center'    }` |
-| `hideButtons` | | Hide the `previous` or `next` Button|
+| `autoFinishByExit` | `Boolean` | `true` (Close `overlay` when click `exit` Button)
+| `hideButtons` | | Hide the `previous`, `next` or `exit` Button|
 | `hideButtons.previous` | `Boolean` | `false` |
 | `hideButtons.next` | `Boolean` | `false` |
+| `hideButtons.exit` | `Boolean` | `false` |
 | `labels` | | |
 | `labels.previousButton` | `String` | `Previous` |
 | `labels.nextButton` | `String` | `Next` |

--- a/src/components/VOnboardingStep.vue
+++ b/src/components/VOnboardingStep.vue
@@ -64,7 +64,7 @@ export default defineComponent({
     const show = ref(false)
 
     const state = inject(STATE_INJECT_KEY, {} as Ref<OnboardingState>)
-    const { step, isFirstStep, isLastStep, options, next, previous, exit, finish } = toRefs(state.value)
+    const { step, isFirstStep, isLastStep, options, next, previous, exit: stateExit, finish } = toRefs(state.value)
 
     const mergedOptions = computed(() => merge({}, options?.value, step.value.options))
 
@@ -105,8 +105,8 @@ export default defineComponent({
     };
     watch(step, attachElement, { immediate: true })
 
-    const onExitButtonClick = () => {
-      exit.value()
+    const exit = () => {
+      stateExit.value()
       if (mergedOptions.value?.autoFinishByExit) {
         finish.value()
       }
@@ -121,7 +121,7 @@ export default defineComponent({
       step,
       isFirstStep,
       isLastStep,
-      onExitButtonClick,
+      exit,
       finish,
       isButtonVisible,
       buttonLabels

--- a/src/components/VOnboardingStep.vue
+++ b/src/components/VOnboardingStep.vue
@@ -11,7 +11,7 @@
               v-if="step.content.title"
               class="v-onboarding-item__header-title"
             >{{ step.content.title }}</span>
-            <button @click="exit" class="v-onboarding-item__header-close">
+            <button v-if="isButtonVisible.exit" @click="onExitButtonClick" class="v-onboarding-item__header-close">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 class="h-4 w-4"
@@ -71,7 +71,8 @@ export default defineComponent({
     const isButtonVisible = computed(() => {
       return {
         previous: !mergedOptions.value.hideButtons?.previous,
-        next: !mergedOptions.value.hideButtons?.next
+        next: !mergedOptions.value.hideButtons?.next,
+        exit: !mergedOptions.value.hideButtons?.exit
       }
     })
 
@@ -103,6 +104,14 @@ export default defineComponent({
       }
     };
     watch(step, attachElement, { immediate: true })
+
+    const onExitButtonClick = () => {
+      exit.value()
+      if (mergedOptions.value?.autoFinishByExit) {
+        finish.value()
+      }
+    }
+
     return {
       stepElement,
       next,
@@ -112,7 +121,7 @@ export default defineComponent({
       step,
       isFirstStep,
       isLastStep,
-      exit,
+      onExitButtonClick,
       finish,
       isButtonVisible,
       buttonLabels

--- a/src/components/VOnboardingStep.vue
+++ b/src/components/VOnboardingStep.vue
@@ -11,7 +11,7 @@
               v-if="step.content.title"
               class="v-onboarding-item__header-title"
             >{{ step.content.title }}</span>
-            <button v-if="isButtonVisible.exit" @click="onExitButtonClick" class="v-onboarding-item__header-close">
+            <button v-if="isButtonVisible.exit" @click="exit" class="v-onboarding-item__header-close">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 class="h-4 w-4"

--- a/src/types/VOnboardingWrapper.ts
+++ b/src/types/VOnboardingWrapper.ts
@@ -23,9 +23,11 @@ export interface VOnboardingWrapperOptions {
     enabled?: boolean
     options?: ScrollIntoViewOptions
   },
+  autoFinishByExit?: boolean
   hideButtons?: {
     previous?: boolean
     next?: boolean
+    exit?: boolean
   },
   labels?: {
     previousButton?: string
@@ -49,6 +51,7 @@ export const defaultVOnboardingWrapperOptions: VOnboardingWrapperOptions = {
       inline: 'center'
     }
   },
+  autoFinishByExit: true,
   labels: {
     previousButton: 'Previous',
     nextButton: 'Next',
@@ -56,6 +59,7 @@ export const defaultVOnboardingWrapperOptions: VOnboardingWrapperOptions = {
   },
   hideButtons: {
     previous: false,
-    next: false
+    next: false,
+    exit: false
   }
 }


### PR DESCRIPTION
Initial concept: https://github.com/fatihsolhan/v-onboarding/issues/72#issuecomment-1541918704

![image](https://github.com/fatihsolhan/v-onboarding/assets/67325669/06074844-e7ae-4ffb-b624-3b03b6012fde)
`X` --> `exit`

### Now

When we click on the `exit` button, we need to implement the necessary code to hide the overlay, but the `exit` button automatically appears. I have come up with two possible solutions that can be applied separately, so I have implemented both of them.

<br><hr><br>
### 1.) (Auto) Finish By Exit

When we click on the `exit` button, with the help of a setting, **we can easily specify whether we want the step sequence to be completed or not**, but the option to inject our own script remains available through the `@exit` emit.
(If we set the autoFinish to false, we still have the option to run the finish (with `@exit` emit using), so I found it appropriate to include the 'auto' prefix.)

#### Default
`options.autoFinishByExit`: `true`

#### Usage
 ```js
const options = {
    autoFinishByExit: false // here
}
```
```html
<VOnboardingWrapper 
    ref="wrapper"
    :options="options" <!-- required -->
    :steps="onboardingSteps" 
 />
```

<br><hr><br>
### 2.) Hide Exit Button

We provide the option to hide the `exit` button, similar to the `prev` and `next` buttons.

#### Default
`options.hideButtons.exit`: `false`

#### Usage
 ```js
const options = {
    hideButtons: {
        exit: true // here
    },
}
```
```html
<VOnboardingWrapper 
    ref="wrapper"
    :options="options" <!-- required -->
    :steps="onboardingSteps" 
 />
```