### PR TITLE
fix: `toRefs()` expects a reactive object but received a plain one (warning)

### DIFF
--- a/src/components/VOnboardingStep.vue
+++ b/src/components/VOnboardingStep.vue
@@ -55,7 +55,7 @@
 import { OnboardingState, STATE_INJECT_KEY } from '@/types/index';
 import { createPopper } from '@popperjs/core';
 import merge from 'lodash.merge';
-import { Ref, computed, defineComponent, inject, nextTick, ref, toRefs, watch } from 'vue';
+import { Ref, computed, defineComponent, inject, nextTick, ref, watch } from 'vue';
 import useGetElement from '../composables/useGetElement';
 import useSvgOverlay from '../composables/useSvgOverlay';
 export default defineComponent({

--- a/src/components/VOnboardingStep.vue
+++ b/src/components/VOnboardingStep.vue
@@ -64,7 +64,7 @@ export default defineComponent({
     const show = ref(false)
 
     const state = inject(STATE_INJECT_KEY, {} as Ref<OnboardingState>)
-    const { step, isFirstStep, isLastStep, options, next, previous, exit: stateExit, finish } = toRefs(state.value)
+    const { step, isFirstStep, isLastStep, options, next, previous, exit: stateExit, finish } = state.value
 
     const mergedOptions = computed(() => merge({}, options?.value, step.value.options))
 
@@ -107,9 +107,9 @@ export default defineComponent({
     watch(step, attachElement, { immediate: true })
 
     const exit = () => {
-      stateExit.value()
+      stateExit()
       if (mergedOptions.value?.autoFinishByExit) {
-        finish.value()
+        finish()
       }
     }
 


### PR DESCRIPTION
### Problem

```js
const state = inject(STATE_INJECT_KEY, {} as Ref<OnboardingState>)
const { step, isFirstStep, isLastStep, options, next, previous, exit: stateExit, finish } = toRefs(state.value)
```

> [!WARNING]
> `toRefs()` expects a reactive object but received a plain one.

### Solution

```js
const state = inject(STATE_INJECT_KEY, {} as Ref<OnboardingState>)
const { step, isFirstStep, isLastStep, options, next, previous, exit: stateExit, finish } = state.value
```

**The use of toRefs is unnecessary** when we do not intend to transform a reactive object. The type of the `state` variable used in `VOnboardingStep.vue` is already of type `ref()`. I consider the per-variable transformation performed on it to be unnecessary; the variables can be declared without using `toRefs()` as I did in the modifications of this PR. This eliminates the warning message. **The type of the `state` will always be `ref()`, so using `toRefs()` is not justified.**

> [!NOTE]
>
> **Converts a reactive object to a plain object** where each property of the resulting object is a ref pointing to the corresponding property of the original object. Each individual ref is created using [toRef()](https://vuejs.org/api/reactivity-utilities.html#toref).
>
> **Vue Docs - [toRefs](https://vuejs.org/api/reactivity-utilities.html#torefs)**