### PR TITLE
(ts) fix: `StepEntity.content` is required

### DIFF
--- a/src/types/StepEntity.d.ts
+++ b/src/types/StepEntity.d.ts
@@ -3,7 +3,7 @@ import { VOnboardingWrapperOptions } from "@/types/VOnboardingWrapper";
 export type AttachableElement = string | (() => Element | null)
 
 export interface StepEntity {
-  content?: {
+  content: {
     title: string;
     description?: string;
   }


### PR DESCRIPTION
Since filling out `StepEntity.content.title` is mandatory, providing `StepEntity.content` itself is also required.