### PR TITLE
feat: Raw HTML support

### DIFF
--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -77,7 +77,8 @@ export default defineComponent({
         },
         content: {
           title: 'Nice to see you here!',
-          description: 'You can use v-onboarding to show some information about your app, or to explain how to use it',
+          description: 'You can use <strong>v-onboarding</strong> to show some information about your app, or to explain how to use it',
+          html: true
         }
       },
       {

--- a/docs/pages/3.props/1.steps.md
+++ b/docs/pages/3.props/1.steps.md
@@ -13,6 +13,7 @@ title: steps
   content: {
     title: "..."
     description: "..."
+    html: false
   },
   on: {
     beforeStep: function() {},
@@ -29,6 +30,7 @@ title: steps
 | `content` | `Object` | **Optional** |
 | `content.title` | `String` | **Optional** | Title to use in onboarding step |
 | `content.description` | `String` | **Optional** | Description to use in onboarding step |
+| `content.html` | `Boolean` | **Optional** | If its set to `true`, the `content.description` will be rendered in the default template using [`v-html`](https://vuejs.org/guide/essentials/template-syntax.html#raw-html) |
 | `on` | `Object` | **Optional** |
 | `on.beforeStep` | `Function` `AsyncFunction` | **Optional** | Function to run before showing the step |
 | `on.afterStep ` | `Function` `AsyncFunction` | **Optional** | Function to run after showing the step |

--- a/src/components/VOnboardingStep.vue
+++ b/src/components/VOnboardingStep.vue
@@ -29,7 +29,12 @@
             </button>
           </div>
           <p
-            v-if="step.content.description"
+            v-if="step.content.description && step.content.html"
+            class="v-onboarding-item__description"
+            v-html="step.content.description"
+          />
+          <p
+            v-else-if="step.content.description"
             class="v-onboarding-item__description"
           >{{ step.content.description }}</p>
           <div class="v-onboarding-item__actions">

--- a/src/types/StepEntity.d.ts
+++ b/src/types/StepEntity.d.ts
@@ -6,6 +6,7 @@ export interface StepEntity {
   content?: {
     title: string;
     description?: string;
+    html?: boolean
   }
   on?: {
     beforeStep?: () => void | Promise<void>


### PR DESCRIPTION
Inspired by: https://github.com/fatihsolhan/v-onboarding/issues/79 (issue)

Actually, it's not a major change, but **it avoids generating a complete template reproduction just to implement HTML code in the description**.

> [!WARNING]
> It's important to note that in this case, it's up to the developer to only accept HTML code from trusted sources and validate them as needed, for example, using [DOMPurify](https://www.npmjs.com/package/dompurify) when possible.

Therefore, its default value is `false` by not being declared. So its current usage doesn't change, but in the future, there will be the possibility of implementing HTML code as well.

<details>
  <summary>Examples</summary>

### 1. without `content.html`
```js
// without content.html (result is not v-html)
const steps = [{
  content: {
    title: "Lorem ipsum...",
    description: "Lorem <strong>ipsum</strong> dolorem...."
  }
}]
```
**Result:** `Lorem <strong>ipsum</strong> dolorem...`

### 2. with `content.html = false`
```js
// with content.html = false (result is not v-html)
const steps = [{
  content: {
    title: "Lorem ipsum...",
    description: "Lorem <strong>ipsum</strong> dolorem...",
    html: false
  }
}]
```
**Result:** `Lorem <strong>ipsum</strong> dolorem...`

### 3. with `content.html = true` --- just here enabled html tags
```js
// with content.html = true (result is v-html)
const steps = [{
  content: {
    title: "Lorem ipsum...",
    description: "Lorem <strong>ipsum</strong> dolorem...",
    html: true
  }
}]
```
**Result:** Lorem **ipsum** dolorem...
</details>