### PR TITLE
feat: enhanced hooks (declaring options for advanced functionality)

### DIFF
--- a/docs/pages/3.props/1.steps.md
+++ b/docs/pages/3.props/1.steps.md
@@ -15,8 +15,8 @@ title: steps
     description: "..."
   },
   on: {
-    beforeStep: function() {},
-    afterStep: function() {}
+    beforeStep: function (options) { ... },
+    afterStep: function (options) { ... }
   },
   options: {}
 }
@@ -30,6 +30,6 @@ title: steps
 | `content.title` | `String` | **Optional** | Title to use in onboarding step |
 | `content.description` | `String` | **Optional** | Description to use in onboarding step |
 | `on` | `Object` | **Optional** |
-| `on.beforeStep` | `Function` `AsyncFunction` | **Optional** | Function to run before showing the step |
-| `on.afterStep ` | `Function` `AsyncFunction` | **Optional** | Function to run after showing the step |
+| `on.beforeStep` | `Function` `AsyncFunction` | **Optional** | Function to run before showing the step ([More information](/props/hooks#onBeforeStep)) |
+| `on.afterStep ` | `Function` `AsyncFunction` | **Optional** | Function to run after showing the step ([More information](/props/hooks#onAfterStep)) |
 | `options` | [Options](/props/options) | **Optional** | Option for step. Overrides the `VOnboardingWrapper` options |

--- a/docs/pages/3.props/3.hooks.md
+++ b/docs/pages/3.props/3.hooks.md
@@ -19,6 +19,8 @@ It runs before the step is 'opened'.
 
 | Option Name | Type | Default | Description |
 | :-------- | :-------- | :-------- | :-------- |
+| `index` | `Number` | `privateIndex` | The index of the current step, the first step being indexed as 0 |
+| `step` | `StepEntity` | `activeStep` | The data and parameters of the current step |
 | `direction` | `Number` | `1` or `-1` | `-1` if we jump to a previous step in the order of steps; otherwise, `1.` |
 | `isForward` | `Boolean` | `direction === Direction.FORWARD` | `true` if indeed the next element will appear |
 | `isBackward` | `Boolean` | `direction === Direction.BACKWARD` | `true` if in fact the previous element will be displayed |
@@ -39,6 +41,8 @@ It runs before the step is 'closed'.
 
 | Option Name | Type | Default | Description |
 | :-------- | :-------- | :-------- | :-------- |
+| `index` | `Number` | `privateIndex` | The index of the current step, the first step being indexed as 0 |
+| `step` | `StepEntity` | `activeStep` | The data and parameters of the current step |
 | `direction` | `Number` | `1` or `-1` | `-1` if we jump to a previous step in the order of steps; otherwise, `1.` |
 | `isForward` | `Boolean` | `direction === Direction.FORWARD` | `true` if indeed the next element will appear |
 | `isBackward` | `Boolean` | `direction === Direction.BACKWARD` | `true` if in fact the previous element will be displayed |

--- a/docs/pages/3.props/3.hooks.md
+++ b/docs/pages/3.props/3.hooks.md
@@ -20,6 +20,8 @@ It runs before the step is 'opened'.
 | Option Name | Type | Default | Description |
 | :-------- | :-------- | :-------- | :-------- |
 | `direction` | `Number` | `1` or `-1` | `-1` if we jump to a previous step in the order of steps; otherwise, `1.` |
+| `isForward` | `Boolean` | `direction === Direction.FORWARD` | `true` if indeed the next element will appear |
+| `isBackward` | `Boolean` | `direction === Direction.BACKWARD` | `true` if in fact the previous element will be displayed |
 
 ### onAfterStep
 
@@ -38,3 +40,5 @@ It runs before the step is 'closed'.
 | Option Name | Type | Default | Description |
 | :-------- | :-------- | :-------- | :-------- |
 | `direction` | `Number` | `1` or `-1` | `-1` if we jump to a previous step in the order of steps; otherwise, `1.` |
+| `isForward` | `Boolean` | `direction === Direction.FORWARD` | `true` if indeed the next element will appear |
+| `isBackward` | `Boolean` | `direction === Direction.BACKWARD` | `true` if in fact the previous element will be displayed |

--- a/docs/pages/3.props/3.hooks.md
+++ b/docs/pages/3.props/3.hooks.md
@@ -1,0 +1,40 @@
+---
+title: hooks
+---
+Hooks can be defined individually for each `Step`.
+
+### onBeforeStep
+
+It runs before the step is 'opened'.
+
+```js
+{
+  on: {
+    beforeStep: function (options) {
+      // The logic written here will run before displaying the step, and it can be customized with settings
+    }
+  }
+}
+```
+
+| Option Name | Type | Default | Description |
+| :-------- | :-------- | :-------- | :-------- |
+| `direction` | `Number` | `1` or `-1` | `-1` if we jump to a previous step in the order of steps; otherwise, `1.` |
+
+### onAfterStep
+
+It runs before the step is 'closed'.
+
+```js
+{
+  on: {
+    beforeStep: function (options) {
+      // The logic written here will run before hiding the step, and it can be customized with settings
+    }
+  }
+}
+```
+
+| Option Name | Type | Default | Description |
+| :-------- | :-------- | :-------- | :-------- |
+| `direction` | `Number` | `1` or `-1` | `-1` if we jump to a previous step in the order of steps; otherwise, `1.` |

--- a/src/components/VOnboardingWrapper.vue
+++ b/src/components/VOnboardingWrapper.vue
@@ -44,6 +44,8 @@ export default defineComponent({
     watch(index, async (newIndex, oldIndex) => {
       const direction: number = newIndex < oldIndex ? Direction.BACKWARD : Direction.FORWARD
       const globalHookOptions = {
+        index: privateIndex.value,
+        step: activeStep.value,
         direction: direction,
         isForward: direction === Direction.FORWARD,
         isBackward: direction === Direction.BACKWARD,

--- a/src/components/VOnboardingWrapper.vue
+++ b/src/components/VOnboardingWrapper.vue
@@ -43,17 +43,24 @@ export default defineComponent({
     const activeStep = computed(() => props.steps?.[privateIndex.value])
     watch(index, async (newIndex, oldIndex) => {
       const direction: number = newIndex < oldIndex ? Direction.BACKWARD : Direction.FORWARD
+      const globalHookOptions = {
+        direction: direction,
+        isForward: direction === Direction.FORWARD,
+        isBackward: direction === Direction.BACKWARD,
+      }
       const oldStep = props.steps?.[oldIndex]
       if (oldStep) {
         const afterHookOptions: onAfterStepOptions = {
-          direction: direction
+          ...globalHookOptions,
+          // custom afterHookOptions here
         }
         await afterHook(oldStep, afterHookOptions)
       }
       const newStep = props.steps?.[newIndex]
       if (newStep) {
         const beforeHookOptions: onBeforeStepOptions = {
-          direction: direction
+          ...globalHookOptions,
+          // custom afterHookOptions here
         }
         await beforeHook(newStep, beforeHookOptions)
       }

--- a/src/components/VOnboardingWrapper.vue
+++ b/src/components/VOnboardingWrapper.vue
@@ -44,8 +44,6 @@ export default defineComponent({
     watch(index, async (newIndex, oldIndex) => {
       const direction: number = newIndex < oldIndex ? Direction.BACKWARD : Direction.FORWARD
       const globalHookOptions = {
-        index: privateIndex.value,
-        step: activeStep.value,
         direction: direction,
         isForward: direction === Direction.FORWARD,
         isBackward: direction === Direction.BACKWARD,
@@ -55,6 +53,8 @@ export default defineComponent({
         const afterHookOptions: onAfterStepOptions = {
           ...globalHookOptions,
           // custom afterHookOptions here
+          index: oldIndex,
+          step: oldStep,
         }
         await afterHook(oldStep, afterHookOptions)
       }
@@ -63,6 +63,8 @@ export default defineComponent({
         const beforeHookOptions: onBeforeStepOptions = {
           ...globalHookOptions,
           // custom afterHookOptions here
+          index: newIndex,
+          step: newStep,
         }
         await beforeHook(newStep, beforeHookOptions)
       }

--- a/src/types/StepEntity.d.ts
+++ b/src/types/StepEntity.d.ts
@@ -2,14 +2,24 @@ import { VOnboardingWrapperOptions } from "@/types/VOnboardingWrapper";
 
 export type AttachableElement = string | (() => Element | null)
 
+interface onGlobalOptions {
+  direction: 1 | -1 | number
+}
+export type onBeforeStepOptions = onGlobalOptions & {
+  // custom options here
+}
+export type onAfterStepOptions = onGlobalOptions & {
+  // custom options here
+}
+
 export interface StepEntity {
   content?: {
     title: string;
     description?: string;
   }
   on?: {
-    beforeStep?: () => void | Promise<void>
-    afterStep?: () => void | Promise<void>
+    beforeStep?: (options?: onBeforeStepOptions) => void | Promise<void>
+    afterStep?: (options?: onAfterStepOptions) => void | Promise<void>
   },
   attachTo: {
     element: AttachableElement,
@@ -17,5 +27,3 @@ export interface StepEntity {
   }
   options?: VOnboardingWrapperOptions
 }
-
-

--- a/src/types/StepEntity.d.ts
+++ b/src/types/StepEntity.d.ts
@@ -3,6 +3,8 @@ import { VOnboardingWrapperOptions } from "@/types/VOnboardingWrapper";
 export type AttachableElement = string | (() => Element | null)
 
 interface onGlobalOptions {
+  index: number
+  step: StepEntity
   direction: 1 | -1 | number
   isForward: boolean
   isBackward: boolean

--- a/src/types/StepEntity.d.ts
+++ b/src/types/StepEntity.d.ts
@@ -4,6 +4,8 @@ export type AttachableElement = string | (() => Element | null)
 
 interface onGlobalOptions {
   direction: 1 | -1 | number
+  isForward: boolean
+  isBackward: boolean
 }
 export type onBeforeStepOptions = onGlobalOptions & {
   // custom options here

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,3 +19,8 @@ export const OnboardingState = {
   IDLE: -1,
   FINISHED: -2
 }
+
+export const Direction = {
+  BACKWARD: -1,
+  FORWARD: 1
+}


### PR DESCRIPTION
## Feature

Currently, there are two defined hooks: `beforeHook` and `afterHook`. You can implement your own custom functions to run at the end of each step within the `on.beforeStep` and `on.afterStep`.
Currently, it is not possible to associate and pass settings to the hooks, including the developer-defined extra functions.

There has been **a demand**, considering that within the hook, we can determine whether the current step is '**previous**' or '**next**' relative to the **previously displayed step**, i.e., whether the step is moving '**backward**' or '**forward**'.

At first, I thought of declaring this as a variable and created the `direction` function parameter. However, I continued to refine the idea and instead declared it as `options`, serving as the parameter for hook settings. As a result, both hooks have currently expanded with a single setting for specifying the direction. However, in the future, other hook-specific or global settings can also be passed to the functions defined by the developer.

## Before this feature

```js
{
  on: {
    beforeStep: () => console.log("I don't know if we were going backwards or forwards now"),
    afterStep: () => console.log("I don't know if we were going backwards or forwards now"),
  }
}
```

I have no way to distinguish the direction of the step, so the function declared here runs regardless of whether I stepped forward or backward to this question. However, it might only make sense in one of these cases.

## With feature

```ts
// typescript for hook options

// global options
interface onGlobalOptions {
  index: number
  step: StepEntity
  direction: 1 | -1 | number
  isForward: boolean
  isBackward: boolean
}
// options for beforeStep
export type onBeforeStepOptions = onGlobalOptions & {
  // custom options here
}
// options for afterStep
export type onAfterStepOptions = onGlobalOptions & {
  // custom options here
}
```
```js
// declared directions
export const Direction = {
  BACKWARD: -1,
  FORWARD: 1
}
```

```js
{
  on: {
    beforeStep: ({ direction }) => console.log(`Current direction: ${direction > 0 ? "forward" : "backward"}`),
    afterStep: (options) => console.log(`Current direction: ${options.isForward === true ? "forward" : "backward"}`),
  }
}
```

So, in short, the opportunity arose within the hook to distinguish when a code snippet should run. For example, you might want to run an animation when moving forward, but it may not make sense when moving backward.

## Access to the data of the step (inspired by [hackathi](https://github.com/hackathi))

By creating hook options, you can easily pass the data of the current step to the function, allowing you to create dynamic functions using it. As [hackathi](https://github.com/hackathi) mentioned, this can be easily achieved by passing the `StepEntity`. Furthermore, the index of the current step can also be passed, which I have also implemented.

```js
function exampleGlobalStepHook (options) {
  if (options.index < 5) console.log("Initial steps")
  else console.log("Advanced settings")

  if (options.step.content.description.length < 30) console.log("Easy")
  else console.log("Hard")
}
```

```js
{
  on: {
    beforeStep: exampleGlobalStepHook,
    afterStep: exampleGlobalStepHook,
  }
}
```

### Updated

- Added `isForward` and `isBackward` options to hooks.
- Added `index` and `step` options to hooks.