### PR TITLE
fix(use-svg-overlay): capture scroll events

### DIFF
--- a/src/composables/useSvgOverlay.ts
+++ b/src/composables/useSvgOverlay.ts
@@ -60,12 +60,12 @@ export default function useSvgOverlay() {
   }
 
   onMounted(() => {
-    window.addEventListener('scroll', onScroll)
+    window.addEventListener('scroll', onScroll, { capture: true })
     window.addEventListener('resize', onScroll)
   })
 
   onUnmounted(() => {
-    window.removeEventListener('scroll', onScroll)
+    window.removeEventListener('scroll', onScroll, { capture: true })
     window.removeEventListener('resize', onScroll)
   })
   return {


### PR DESCRIPTION
When using scroll behavior of "smooth" the highlight rectangle might end up being misplaced when the scrolling occurs inside of a nested element. Capturing the event should catch the nested scrolling and update the highlighted area accordingly.

It might be related to https://github.com/fatihsolhan/v-onboarding/issues/94 but without a demo I can't be sure.