### PR TITLE
fix(v-onboarding-step): focus trap disable scroll

### DIFF
--- a/src/components/VOnboardingStep.vue
+++ b/src/components/VOnboardingStep.vue
@@ -93,7 +93,7 @@ export default defineComponent({
     const { updatePath, path } = useSvgOverlay();
 
     const stepElement = ref<HTMLElement>();
-    const focusTrap = useFocusTrap(stepElement)
+    const focusTrap = useFocusTrap(stepElement, { preventScroll: true })
     watch(show, async (value) => {
       await nextTick()
       // deactivate first to prevent potential trapped states


### PR DESCRIPTION
I have been running into issues where sometimes the focus trap would instantly scroll to an element.

To my understanding there is never a case where we would like to do this because the scrollToStep options should take care of this at all times.

- scrollToStep.enabled === false - We never want to scroll.
- scrollToStep.enabled === true && scrollToStep.options.behavior === "instant" - We scroll instantly anyway, no need to scroll during the focus.
- scrollToStep.enabled === true && scrollToStep.options.behavior === "smooth" - We scroll smoothing, we don't want the instant scroll triggered by the focus trap to interfere