### PR TITLE
fix(css): correct arrow position for left-placed popper

### DIFF
--- a/src/css/v-onboarding.sass
+++ b/src/css/v-onboarding.sass
@@ -90,7 +90,7 @@
   top: calc(var(--v-onboarding-step-arrow-size, 10px) / -2)
 
 [data-v-onboarding-wrapper] [data-popper-placement^='left'] > [data-popper-arrow]
-  right: calc(var(--v-onboarding-step-arrow-size, 10px) / -2)
+  right: calc(var(--v-onboarding-step-arrow-size, 10px) / 2)
 
 [data-v-onboarding-wrapper] [data-popper-placement^='right'] > [data-popper-arrow]
   left: calc(var(--v-onboarding-step-arrow-size, 10px) / -2)


### PR DESCRIPTION
## Summary
- Fix incorrect arrow positioning for left-placed popper by changing the calculation from `/ -2` to `/ 2`