### PR TITLE
feat: add Vue template ref support for attachTo.element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ yarn-error.log*
 *.sw*
 
 # docs
+docs/.vitepress/
 docs/.nuxt/
 docs/static/sw.js

--- a/README.md
+++ b/README.md
@@ -71,6 +71,33 @@ const steps = [
 </template>
 ```
 
+## Using Vue Template Refs
+
+You can attach steps to elements using Vue template refs:
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { VOnboardingWrapper } from 'v-onboarding'
+import 'v-onboarding/dist/style.css'
+
+const wrapper = ref(null)
+const buttonRef = ref(null)
+
+const steps = [
+  {
+    attachTo: { element: buttonRef },
+    content: { title: 'Click me!', description: 'This button uses a template ref.' }
+  }
+]
+</script>
+
+<template>
+  <VOnboardingWrapper ref="wrapper" :steps="steps" />
+  <button ref="buttonRef" @click="wrapper?.start()">Start Tour</button>
+</template>
+```
+
 ## Custom Step UI
 
 Use the default slot to create your own step UI:

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -81,7 +81,7 @@
         </h1>
 
         <p class="text-[var(--color-text-muted)] text-lg sm:text-xl max-w-2xl mb-10 animate-fade-up delay-2">
-          A lightweight, fully-typed onboarding component for Vue 3.
+          A fully-typed, customizable onboarding component for Vue 3.
           Create product tours, feature highlights, and step-by-step guides with ease.
         </p>
 
@@ -234,7 +234,7 @@
             </div>
           </div>
 
-          <div id="code-block" class="code-block p-6">
+          <div ref="codeBlockRef" id="code-block" class="code-block p-6">
             <pre><span class="comment">// Define your tour steps</span>
 <span class="keyword">const</span> steps = [
   {
@@ -342,6 +342,8 @@ import type { StepEntity } from 'v-onboarding'
 const wrapper = ref<InstanceType<typeof VOnboardingWrapper> | null>(null)
 const { start, finish } = useVOnboarding(wrapper)
 
+const codeBlockRef = ref<HTMLElement | null>(null)
+
 const themes = ['step-theme-default', 'step-theme-accent', 'step-theme-warm', 'step-theme-cool', 'step-theme-purple']
 
 const setTheme = (theme: string) => {
@@ -407,10 +409,10 @@ const steps = computed<StepEntity[]>(() => [
     }
   },
   {
-    attachTo: { element: '#code-block' },
+    attachTo: { element: codeBlockRef },
     content: {
       title: 'Simple Setup',
-      description: 'Just a few lines of code to get started. Define steps, wrap your content, and go!'
+      description: 'Just a few lines of code to get started. This step uses a Vue template ref!'
     },
     options: {
       scrollToStep: {

--- a/docs/api/steps.md
+++ b/docs/api/steps.md
@@ -5,7 +5,7 @@
 ```ts
 interface Step {
   attachTo: {
-    element: string | HTMLElement | Ref<HTMLElement>
+    element: string | (() => Element | null) | Ref<Element | null | undefined>
   }
   content?: {
     title?: string
@@ -29,15 +29,12 @@ Specifies which element the step tooltip should point to.
 // CSS Selector
 { attachTo: { element: '#my-element' } }
 
-// Class selector
-{ attachTo: { element: '.nav-button' } }
-
-// Vue ref
+// Vue template ref
 const buttonRef = ref(null)
 { attachTo: { element: buttonRef } }
 
-// Direct element reference
-{ attachTo: { element: document.getElementById('my-element') } }
+// Getter function (for dynamic elements)
+{ attachTo: { element: () => document.querySelector('.dynamic-element') } }
 ```
 
 ### `content`

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -7,7 +7,7 @@ Each step in your tour is an object with the following structure:
 ```ts
 interface Step {
   attachTo: {
-    element: string | HTMLElement  // CSS selector or element reference
+    element: string | (() => Element | null) | Ref<Element | null>  // CSS selector, function, or Vue ref
   }
   content?: {
     title?: string
@@ -38,15 +38,19 @@ const steps = [
 ]
 ```
 
-### Using Element References
+### Using Vue Template Refs
+
+You can pass Vue template refs directly to `attachTo.element`. This is useful when you need to reference elements that don't have a unique selector:
 
 ```vue
 <template>
   <button ref="myButton">Click me</button>
+  <VOnboardingWrapper :steps="steps" />
 </template>
 
 <script setup>
 import { ref } from 'vue'
+import { VOnboardingWrapper } from 'v-onboarding'
 
 const myButton = ref(null)
 
@@ -57,6 +61,21 @@ const steps = [
   }
 ]
 </script>
+```
+
+### Using Getter Functions
+
+For dynamic element resolution, you can use a function that returns an element:
+
+```ts
+const steps = [
+  {
+    attachTo: {
+      element: () => document.querySelector('.dynamic-element')
+    },
+    content: { title: 'Dynamic element' }
+  }
+]
 ```
 
 ## Step Options

--- a/src/composables/useGetElement.ts
+++ b/src/composables/useGetElement.ts
@@ -1,3 +1,4 @@
+import { isRef } from "vue";
 import type { AttachableElement } from "@/types/lib";
 
 /**
@@ -21,6 +22,9 @@ function querySelectorDeep(selector: string, root: Document | ShadowRoot | Eleme
 }
 
 export default function useGetElement(element: AttachableElement) {
+  if (isRef(element)) {
+    return element.value ?? null;
+  }
   if (typeof element === "string") {
     // First try normal querySelector (faster)
     const found = document.querySelector(element);

--- a/src/types/lib/index.ts
+++ b/src/types/lib/index.ts
@@ -1,5 +1,5 @@
 import type { createPopper } from "@popperjs/core/lib/createPopper";
-import type { DefineComponent } from 'vue';
+import type { DefineComponent, Ref } from 'vue';
 
 declare const VOnboardingWrapper: DefineComponent<{
   steps: StepEntity[]
@@ -54,7 +54,7 @@ interface VOnboardingWrapperOptions {
   hideNextStepDuringHook?: boolean;
 }
 
-type AttachableElement = string | (() => Element | null)
+type AttachableElement = string | (() => Element | null) | Ref<Element | null | undefined>
 
 interface onGlobalOptions {
   index: number

--- a/tests/useGetElement.test.ts
+++ b/tests/useGetElement.test.ts
@@ -1,3 +1,4 @@
+import { ref } from 'vue'
 import useGetElement from '@/composables/useGetElement'
 
 describe('useGetElement', () => {
@@ -92,5 +93,51 @@ describe('useGetElement', () => {
     // Should find the regular DOM element first
     const found = useGetElement('#shared-id')
     expect(found?.className).toBe('regular')
+  })
+
+  it('should find element from Vue ref with valid element', () => {
+    const element = document.createElement('div')
+    element.id = 'ref-element'
+    document.body.appendChild(element)
+
+    const elementRef = ref<Element | null>(element)
+    const found = useGetElement(elementRef)
+    expect(found).not.toBeNull()
+    expect(found?.id).toBe('ref-element')
+  })
+
+  it('should return null when Vue ref has null value', () => {
+    const elementRef = ref<Element | null>(null)
+    const found = useGetElement(elementRef)
+    expect(found).toBeNull()
+  })
+
+  it('should return null when Vue ref has undefined value', () => {
+    const elementRef = ref<Element | undefined>(undefined)
+    const found = useGetElement(elementRef)
+    expect(found).toBeNull()
+  })
+
+  it('should handle Vue ref that updates', () => {
+    const element1 = document.createElement('div')
+    element1.id = 'element-1'
+    document.body.appendChild(element1)
+
+    const element2 = document.createElement('div')
+    element2.id = 'element-2'
+    document.body.appendChild(element2)
+
+    const elementRef = ref<Element | null>(element1)
+
+    // First call should return element1
+    let found = useGetElement(elementRef)
+    expect(found?.id).toBe('element-1')
+
+    // Update ref to element2
+    elementRef.value = element2
+
+    // Second call should return element2
+    found = useGetElement(elementRef)
+    expect(found?.id).toBe('element-2')
   })
 })

--- a/web-types/web-types.json
+++ b/web-types/web-types.json
@@ -1,7 +1,7 @@
 {
   "framework": "vue",
   "name": "v-onboarding",
-  "version": "2.8.2",
+  "version": "2.10.2",
   "contributions": {
     "html": {
       "description-markup": "markdown",
@@ -41,6 +41,14 @@
                 "type": "VOnboardingWrapperOptions"
               },
               "default": "() => ({})"
+            }
+          ],
+          "events": [
+            {
+              "name": "finish"
+            },
+            {
+              "name": "exit"
             }
           ],
           "slots": [


### PR DESCRIPTION
## Summary

  - Allow passing Vue template refs directly to `attachTo.element` as an alternative to CSS selectors
  - Provides a cleaner, type-safe way to reference elements without needing unique IDs or class names

  ## Changes

  - Add `Ref<Element | null | undefined>` to `AttachableElement` type
  - Handle `isRef()` check in `useGetElement` composable
  - Add 4 tests for ref support (valid element, null, undefined, updates)
  - Update docs with Vue ref examples
  - Add ref usage example in demo

  ## Usage

  ```vue
  <template>
    <button ref="buttonRef">Click me</button>
    <VOnboardingWrapper :steps="steps" />
  </template>

  <script setup>
  import { ref } from 'vue'

  const buttonRef = ref(null)

  const steps = [
    {
      attachTo: { element: buttonRef },
      content: { title: 'Hello!' }
    }
  ]
  </script>
```

Test plan

  - All existing tests pass
  - New ref tests pass (valid element, null, undefined, updates)
  - Demo works with ref-based step