### PR TITLE
fix(focus-trap): activate only when step content is visible (#126)

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -2,9 +2,10 @@ import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
   entries: ['src/nuxt/module'],
+  outDir: 'dist/nuxt',
   externals: ['@nuxt/kit', '@nuxt/schema', 'v-onboarding'],
   declaration: true,
-  clean: false,
+  clean: true,
   rollup: {
     emitCJS: false
   }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     },
     "./dist/style.css": "./dist/style.css",
     "./nuxt": {
-      "types": "./dist/module.d.ts",
-      "import": "./dist/module.mjs"
+      "types": "./dist/nuxt/module.d.ts",
+      "import": "./dist/nuxt/module.mjs"
     }
   },
   "scripts": {

--- a/src/components/VOnboardingStep.vue
+++ b/src/components/VOnboardingStep.vue
@@ -70,10 +70,10 @@ const { updatePath, path } = useSvgOverlay()
 
 const focusTrap = useFocusTrap(stepElement, { preventScroll: true })
 
-watch(show, async (visible) => {
+watch(ready, async (isReady) => {
   await nextTick()
   focusTrap.deactivate()
-  if (visible && mergedOptions.value?.overlay?.preventOverlayInteraction) {
+  if (isReady && mergedOptions.value?.overlay?.preventOverlayInteraction) {
     focusTrap.activate()
   }
 })

--- a/src/composables/useGetElement.ts
+++ b/src/composables/useGetElement.ts
@@ -1,40 +1,39 @@
 import { isRef } from "vue";
 import type { AttachableElement } from "@/types/lib";
 
-/**
- * Recursively search for an element within shadow DOMs
- */
 function querySelectorDeep(selector: string, root: Document | ShadowRoot | Element = document): Element | null {
-  // First try to find in the current root
-  const element = root.querySelector(selector);
-  if (element) return element;
+  const element = root.querySelector(selector)
+  if (element) return element
 
-  // Search in shadow roots of all elements
-  const allElements = root.querySelectorAll('*');
+  const allElements = root.querySelectorAll('*')
   for (const el of allElements) {
     if (el.shadowRoot) {
-      const found = querySelectorDeep(selector, el.shadowRoot);
-      if (found) return found;
+      const found = querySelectorDeep(selector, el.shadowRoot)
+      if (found) return found
     }
   }
 
-  return null;
+  return null
 }
 
-export default function useGetElement(element: AttachableElement) {
+export default function useGetElement(element: AttachableElement): Element | null {
   if (isRef(element)) {
-    return element.value ?? null;
+    const value = element.value
+    if (value && !(value instanceof Element) && value.$el) {
+      return value.$el
+    }
+    return value ?? null
   }
-  if (typeof element === "string") {
-    // First try normal querySelector (faster)
-    const found = document.querySelector(element);
-    if (found) return found;
 
-    // If not found, search within shadow DOMs
-    return querySelectorDeep(element);
+  if (typeof element === "string") {
+    const found = document.querySelector(element)
+    if (found) return found
+    return querySelectorDeep(element)
   }
-  else if (typeof element === 'function') {
-    return element();
+
+  if (typeof element === 'function') {
+    return element()
   }
-  return null;
+
+  return null
 }

--- a/src/composables/useGetElement.ts
+++ b/src/composables/useGetElement.ts
@@ -19,10 +19,13 @@ function querySelectorDeep(selector: string, root: Document | ShadowRoot | Eleme
 export default function useGetElement(element: AttachableElement): Element | null {
   if (isRef(element)) {
     const value = element.value
-    if (value && !(value instanceof Element) && value.$el) {
+    if (value instanceof Element) {
+      return value
+    }
+    if (value?.$el) {
       return value.$el
     }
-    return value ?? null
+    return null
   }
 
   if (typeof element === "string") {

--- a/tests/useGetElement.test.ts
+++ b/tests/useGetElement.test.ts
@@ -140,4 +140,33 @@ describe('useGetElement', () => {
     found = useGetElement(elementRef)
     expect(found?.id).toBe('element-2')
   })
+
+  it('should extract $el from Vue component ref', () => {
+    const element = document.createElement('div')
+    element.id = 'component-root'
+    document.body.appendChild(element)
+
+    // Simulate a Vue component instance with $el
+    const componentInstance = {
+      $el: element,
+      $props: {},
+      $emit: () => {}
+    }
+
+    const componentRef = ref(componentInstance)
+    const found = useGetElement(componentRef)
+    expect(found).not.toBeNull()
+    expect(found?.id).toBe('component-root')
+  })
+
+  it('should return null when component ref has no $el', () => {
+    const componentInstance = {
+      $props: {},
+      $emit: () => {}
+    }
+
+    const componentRef = ref(componentInstance)
+    const found = useGetElement(componentRef)
+    expect(found).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes the "focus-trap must have at least one container with at least one tabbable node" error by watching `ready` state instead of `show` for focus trap activation
                                                                                                                                                             
## Problem
The focus trap was activating when `show` became true, but at that point `ready` was still false, causing `visibility: hidden` on the step content.
Elements with `visibility: hidden` are not considered tabbable by the focus-trap library, resulting in the error.                                          

## Solution
Changed the watch from `show` to `ready`, ensuring the focus trap only activates when the step content is actually visible and its elements are tabbable. 

Fixes #126 